### PR TITLE
docs: drop the Codecov badge and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ width="261"
 <center>
 <!-- markdownlint-enable MD033 MD041 -->
 
-[![PyPI][pypi-badge]][03] [![PyPI Downloads][pypi-downloads-badge]][07] [![License][license-badge]][01] [![Codecov][codecov-badge]][06] [![License][license-badge]][02]
+[![PyPI][pypi-badge]][03] [![PyPI Downloads][pypi-downloads-badge]][07] [![License][license-badge]][01] [![License][license-badge]][02]
 
 • [Website][00]
 • [Report Bug][03]
@@ -683,11 +683,9 @@ of [audioanalyser][05] for their help and support.
 [03]: https://github.com/sebastienrousseau/audioanalyser.github.io/issues "Audio Analyser on GitHub"
 [04]: https://github.com/sebastienrousseau/audioanalyser.github.io/blob/main/CONTRIBUTING.md "Contributing Guidelines"
 [05]: https://github.com/sebastienrousseau/audioanalyser.github.io/graphs/contributors "Contributors"
-[06]: https://codecov.io/github/sebastienrousseau/audioanalyser.github.io?branch=main "Codecov"
 [07]: https://pypi.org/project/audioanalyser/ "Audio Analyser on PyPI"
 
 [banner]: https://cloudcdn.pro/audioanalyser/images/titles/title-audioanalyser.webp "Speech-to-Text & Analysis: Easy, Fast, Accurate."
-[codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/audioanalyser.github.io?style=for-the-badge&token=AaUxKfRiou 'Codecov badge'
 [diagram]: ./audio-analyser-architecture.png "Audio Analyser Architecture"
 [license-badge]: https://img.shields.io/pypi/l/audioanalyser?style=for-the-badge 'License badge'
 [pypi-badge]: https://img.shields.io/pypi/pyversions/audioanalyser.svg?style=for-the-badge 'PyPI badge'


### PR DESCRIPTION
The Codecov badge has always rendered `coverage: unknown` — there is no Codecov data for this repo under its old *or* current name. (For contrast, `pain001` returns `coverage: 98%`, so the check works and is genuinely finding nothing here.)

Nothing uploads coverage, and never has:

- the `pytest` job **doesn't run pytest** — the `pytest --cov` line is commented out (ci.yml:54), so the job only installs dependencies
- the Codecov upload step is commented out too (ci.yml:59)
- `tests/` contains only `__init__.py`
- no `CODECOV_TOKEN` secret is configured

So the badge advertised a metric that has never existed. This removes it from the header plus the `[06]` and `[codecov-badge]` definitions; verified no link reference is left dangling or orphaned.

This doesn't close the door on coverage — it stops claiming it. Wiring it up properly needs a test suite first, which is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)