### PR TITLE
test: add a suite covering the package, and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,18 +47,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-        # python -m pip install pytest pytest-cov
+          python -m pip install pytest pytest-cov
 
-      # Run pytest
-      # - name: ❯ Run pytest 🧪
-        # run: pytest --cov=audioanalyser --cov-report=xml
-
-      # Upload code coverage report to Codecov
-      # - name: ❯ Upload code coverage report to Codecov 📊
-      #   if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      #   uses: codecov/codecov-action@v1
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
+      # Coverage options come from [tool.pytest.ini_options] in pyproject.toml,
+      # including --cov-fail-under, so the gate lives with the project config.
+      - name: ❯ Run pytest 🧪
+        run: pytest
 
   # This job runs flake8 to check for code style issues
   lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,25 @@ force_grid_wrap = 0
 combine_as_imports = true
 known_first_party = "audioanalyser"
 
-[tool.pytest]
-addopts = "--cov=audioanalyser --cov-report=term-missing --cov-report=xml --cov-report=html --cov-fail-under=100"
-testpaths = "tests"
+# pytest reads [tool.pytest.ini_options], not [tool.pytest], and requires
+# addopts to be a list in TOML. As [tool.pytest] with a string it aborted
+# before collecting anything.
+[tool.pytest.ini_options]
+addopts = [
+    "--cov=audioanalyser",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "--cov-fail-under=95",
+]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["audioanalyser"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    # Module entry points; running them would start a server or a recording.
+    "if __name__ == .__main__.:",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,144 @@
+# Copyright (C) 2023-2024 Sebastien Rousseau.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Shared fixtures and import-time shims for the test suite.
+
+Two things have to happen before ``audioanalyser`` is imported, so they run at
+module scope rather than inside a fixture:
+
+1. ``audio_recorder`` imports :mod:`pyaudio`, which needs the PortAudio system
+   library and is not declared in any manifest. A stub keeps the suite runnable
+   on machines and CI images that do not have it.
+2. ``transcribe_audio_files`` reads ``AUDIO_EXTENSION`` at import time, so it
+   has to be present in the environment before the first import.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# --------------------------------------------------------------------------
+# Import-time shims (must precede any `audioanalyser` import)
+# --------------------------------------------------------------------------
+
+if "pyaudio" not in sys.modules:  # pragma: no branch
+    _pyaudio = types.ModuleType("pyaudio")
+    # Values match PortAudio's real constants so tests exercise the same
+    # branches the production code takes.
+    _pyaudio.paInt16 = 8
+    _pyaudio.paInt24 = 4
+    _pyaudio.paInt32 = 2
+    _pyaudio.PyAudio = MagicMock(name="PyAudio")
+    sys.modules["pyaudio"] = _pyaudio
+
+# Read at import time by transcribe_audio_files.
+os.environ.setdefault("AUDIO_EXTENSION", ".wav")
+
+
+# --------------------------------------------------------------------------
+# Environment fixtures
+# --------------------------------------------------------------------------
+
+# Every variable the package reads, so a test never picks up a developer's
+# real credentials or a stray .env from the working tree.
+ALL_ENV_VARS = (
+    "ANALYSIS_DB_TABLE_NAME",
+    "AUDIO_EXTENSION",
+    "AZURE_AUDIO_TEXT_KEY",
+    "AZURE_LANGUAGE_ENDPOINT",
+    "AZURE_LANGUAGE_KEY",
+    "AZURE_TRANSLATOR_ENDPOINT",
+    "AZURE_TRANSLATOR_KEY",
+    "CHANNELS",
+    "CHUNK",
+    "FORMAT",
+    "GPT3_API_KEY",
+    "INPUT_FOLDER",
+    "MAX_OUTPUT_LENGTH",
+    "OUTPUT_TONE",
+    "OUTPUT_VOICE",
+    "PROMPT_LENGTH_RATIO",
+    "PROMPT_STRATEGY",
+    "RATE",
+    "RECOMMENDATIONS_FOLDER",
+    "RECORD_SECONDS",
+    "RECORDS_FOLDER",
+    "REGION",
+    "REPORTS_FOLDER",
+    "TRANSCRIPTS_FOLDER",
+    "TRANSLATIONS_FOLDER",
+    "TRANSLATIONS_LANGUAGES",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Remove every variable the package reads.
+
+    Config classes are built from ``os.getenv`` at construction time, so this
+    gives each test a known-empty starting point that monkeypatch restores.
+    """
+    for var in ALL_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def folders(tmp_path):
+    """Create the folder layout the modules expect and return the paths."""
+    names = (
+        "input",
+        "transcripts",
+        "translations",
+        "reports",
+        "recommendations",
+        "records",
+    )
+    paths = {}
+    for name in names:
+        path = tmp_path / name
+        path.mkdir()
+        paths[name] = path
+    return paths
+
+
+@pytest.fixture
+def full_env(clean_env, folders):
+    """Populate every variable with valid values pointing at tmp folders."""
+    values = {
+        "ANALYSIS_DB_TABLE_NAME": "analysis",
+        "AUDIO_EXTENSION": ".wav",
+        "AZURE_AUDIO_TEXT_KEY": "test-speech-key",
+        "AZURE_LANGUAGE_ENDPOINT": "https://language.example.invalid",
+        "AZURE_LANGUAGE_KEY": "test-language-key",
+        "AZURE_TRANSLATOR_ENDPOINT": "https://translator.example.invalid",
+        "AZURE_TRANSLATOR_KEY": "test-translator-key",
+        "GPT3_API_KEY": "test-openai-key",
+        "INPUT_FOLDER": str(folders["input"]),
+        "RECOMMENDATIONS_FOLDER": str(folders["recommendations"]),
+        "RECORDS_FOLDER": str(folders["records"]),
+        "REGION": "westeurope",
+        "REPORTS_FOLDER": str(folders["reports"]),
+        "TRANSCRIPTS_DB_TABLE_NAME": "transcripts",
+        "TRANSCRIPTS_FOLDER": str(folders["transcripts"]),
+        "TRANSLATIONS_FOLDER": str(folders["translations"]),
+        "TRANSLATIONS_LANGUAGES": "fr,es,de",
+    }
+    for key, value in values.items():
+        clean_env.setenv(key, value)
+    return values

--- a/tests/test_analyze_text_files.py
+++ b/tests/test_analyze_text_files.py
@@ -1,0 +1,280 @@
+# Copyright (C) 2023-2024 Sebastien Rousseau.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for audioanalyser.modules.analyze_text_files.
+
+The module is async, so each test drives it with ``asyncio.run`` rather than
+taking a dependency on pytest-asyncio.
+"""
+
+import asyncio
+import json
+import sqlite3
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from audioanalyser.modules import analyze_text_files as atf
+
+
+def _client(**overrides):
+    """An async-context-manager client returning canned analytics results."""
+    scores = SimpleNamespace(positive=0.8, neutral=0.15, negative=0.05)
+    defaults = {
+        "analyze_sentiment": [
+            SimpleNamespace(sentiment="positive", confidence_scores=scores)
+        ],
+        "recognize_entities": [
+            SimpleNamespace(
+                entities=[
+                    SimpleNamespace(text="Contoso"),
+                    SimpleNamespace(text="Ada"),
+                ]
+            )
+        ],
+        "extract_key_phrases": [
+            SimpleNamespace(key_phrases=["billing", "refund"])
+        ],
+        "detect_language": [
+            SimpleNamespace(
+                primary_language=SimpleNamespace(
+                    name="English", iso6391_name="en"
+                )
+            )
+        ],
+        "recognize_pii_entities": [
+            SimpleNamespace(entities=[SimpleNamespace(text="ada@example.com")])
+        ],
+    }
+    defaults.update(overrides)
+
+    client = MagicMock()
+    for name, value in defaults.items():
+        setattr(client, name, AsyncMock(return_value=value))
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+class TestConfig:
+    def test_reads_every_setting_from_the_environment(self, full_env):
+        config = atf.Config()
+
+        assert config.az_lg_endpoint == "https://language.example.invalid"
+        assert config.az_lg_key == "test-language-key"
+        assert config.db_name == "analysis"
+
+    @pytest.mark.parametrize(
+        "missing",
+        [
+            "AZURE_LANGUAGE_ENDPOINT",
+            "AZURE_LANGUAGE_KEY",
+            "TRANSCRIPTS_FOLDER",
+            "REPORTS_FOLDER",
+            "ANALYSIS_DB_TABLE_NAME",
+        ],
+    )
+    def test_raises_when_a_required_variable_is_absent(
+        self, full_env, clean_env, missing
+    ):
+        clean_env.delenv(missing)
+
+        with pytest.raises(EnvironmentError, match="Missing required"):
+            atf.Config()
+
+
+class TestTextAnalysisConstruction:
+    def test_holds_the_configuration_it_is_given(self, full_env):
+        config = atf.Config()
+
+        assert atf.TextAnalysis(config).config is config
+
+
+class TestAnalyzeText:
+    def test_calls_every_analytics_endpoint_and_maps_the_results(self):
+        client = _client()
+
+        results = asyncio.run(atf.TextAnalysis.analyze_text(client, "hello"))
+
+        client.analyze_sentiment.assert_awaited_once_with(["hello"])
+        client.recognize_pii_entities.assert_awaited_once_with(["hello"])
+        assert results["sentiment"].sentiment == "positive"
+        assert results["language"].primary_language.iso6391_name == "en"
+
+    def test_maps_empty_responses_to_none(self):
+        client = _client(
+            analyze_sentiment=[],
+            recognize_entities=[],
+            extract_key_phrases=[],
+            detect_language=[],
+            recognize_pii_entities=[],
+        )
+
+        results = asyncio.run(atf.TextAnalysis.analyze_text(client, "hello"))
+
+        assert set(results.values()) == {None}
+
+
+class TestSaveResults:
+    def test_writes_the_summary_json_and_database(self, full_env, folders):
+        client = _client()
+        results = asyncio.run(atf.TextAnalysis.analyze_text(client, "hello"))
+
+        asyncio.run(atf.TextAnalysis.save_results("call.txt", results))
+
+        summary = (folders["reports"] / "call_analysis.txt").read_text()
+        assert "Overall Sentiment: positive" in summary
+        assert "Key Entities Identified: Contoso, Ada" in summary
+        assert "Notable Topics: billing, refund" in summary
+        assert "Detected Language: English(en)" in summary
+        assert "(PII): Yes" in summary
+
+        payload = json.loads(
+            (folders["reports"] / "call_analysis.json").read_text()
+        )
+        assert payload["sentiment"]["sentiment"] == "positive"
+
+        with sqlite3.connect(folders["reports"] / "text_analysis.db") as conn:
+            rows = conn.execute("SELECT filename FROM analysis").fetchall()
+        assert rows == [("call.txt",)]
+
+    def test_reports_absence_of_pii(self, full_env, folders):
+        client = _client(recognize_pii_entities=[SimpleNamespace(entities=[])])
+        results = asyncio.run(atf.TextAnalysis.analyze_text(client, "hello"))
+
+        asyncio.run(atf.TextAnalysis.save_results("call.txt", results))
+
+        summary = (folders["reports"] / "call_analysis.txt").read_text()
+        assert "(PII): No" in summary
+
+    def test_omits_sections_whose_results_are_missing(self, full_env, folders):
+        results = {
+            "sentiment": None,
+            "entities": None,
+            "key_phrases": None,
+            "language": None,
+            "pii": None,
+        }
+
+        asyncio.run(atf.TextAnalysis.save_results("call.txt", results))
+
+        summary = (folders["reports"] / "call_analysis.txt").read_text()
+        assert "Overall Sentiment" not in summary
+        assert "Transcription analysis" in summary
+
+    def test_omits_sections_whose_collections_are_empty(
+        self, full_env, folders
+    ):
+        results = {
+            "sentiment": None,
+            "entities": SimpleNamespace(entities=[]),
+            "key_phrases": SimpleNamespace(key_phrases=[]),
+            "language": None,
+            "pii": None,
+        }
+
+        asyncio.run(atf.TextAnalysis.save_results("call.txt", results))
+
+        summary = (folders["reports"] / "call_analysis.txt").read_text()
+        assert "Key Entities Identified" not in summary
+        assert "Notable Topics" not in summary
+
+    def test_creates_the_reports_folder_when_missing(
+        self, full_env, clean_env, tmp_path
+    ):
+        target = tmp_path / "reports-not-created"
+        clean_env.setenv("REPORTS_FOLDER", str(target))
+        results = {
+            k: None
+            for k in (
+                "sentiment",
+                "entities",
+                "key_phrases",
+                "language",
+                "pii",
+            )
+        }
+
+        asyncio.run(atf.TextAnalysis.save_results("call.txt", results))
+
+        assert (target / "call_analysis.txt").exists()
+
+
+class TestProcessText:
+    def test_returns_results_without_saving_when_no_filename_is_given(self):
+        client = _client()
+
+        with patch.object(
+            atf.TextAnalysis, "save_results", new=AsyncMock()
+        ) as save:
+            results = asyncio.run(
+                atf.TextAnalysis.process_text(client, "hello")
+            )
+
+        save.assert_not_awaited()
+        assert results["sentiment"].sentiment == "positive"
+
+    def test_saves_the_results_when_a_filename_is_given(self):
+        client = _client()
+
+        with patch.object(
+            atf.TextAnalysis, "save_results", new=AsyncMock()
+        ) as save:
+            asyncio.run(
+                atf.TextAnalysis.process_text(client, "hello", "call.txt")
+            )
+
+        save.assert_awaited_once()
+        assert save.await_args.args[0] == "call.txt"
+
+
+class TestEntryPoint:
+    def test_processes_each_transcript_in_the_folder(self, full_env, folders):
+        (folders["transcripts"] / "one.txt").write_text("hello")
+        (folders["transcripts"] / "two.txt").write_text("bonjour")
+        (folders["transcripts"] / "skip.md").write_text("not a transcript")
+
+        with patch.object(atf, "TextAnalyticsClient", return_value=_client()):
+            with patch.object(
+                atf.TextAnalysis, "process_text", new=AsyncMock()
+            ) as process:
+                asyncio.run(
+                    atf.analyze_text_files(str(folders["transcripts"]))
+                )
+
+        processed = sorted(
+            call.args[2].rsplit("/", 1)[-1] for call in process.await_args_list
+        )
+        assert processed == ["one.txt", "two.txt"]
+
+    def test_creates_the_reports_folder_when_missing(
+        self, full_env, clean_env, tmp_path
+    ):
+        target = tmp_path / "reports-absent"
+        clean_env.setenv("REPORTS_FOLDER", str(target))
+
+        asyncio.run(atf.analyze_text_files("ignored"))
+
+        assert target.is_dir()
+
+    def test_logs_instead_of_raising_when_configuration_is_invalid(
+        self, full_env, clean_env, caplog
+    ):
+        clean_env.delenv("AZURE_LANGUAGE_KEY")
+
+        asyncio.run(atf.analyze_text_files("ignored"))
+
+        assert "Script execution failed" in caplog.text

--- a/tests/test_audio_recorder.py
+++ b/tests/test_audio_recorder.py
@@ -1,0 +1,281 @@
+# Copyright (C) 2023-2024 Sebastien Rousseau.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for audioanalyser.modules.audio_recorder."""
+
+import os
+import signal
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from audioanalyser.modules import audio_recorder as ar
+
+
+@pytest.fixture
+def settings(tmp_path):
+    return ar.AudioSettings(
+        input_folder=str(tmp_path / "recordings"), record_seconds=1, chunk=1024
+    )
+
+
+@pytest.fixture
+def fake_audio():
+    """A stand-in for pyaudio.PyAudio() with a readable stream."""
+    audio = MagicMock()
+    stream = MagicMock()
+    stream.read.return_value = b"\x00" * 2048
+    audio.open.return_value = stream
+    audio.get_sample_size.return_value = 2
+    with patch.object(ar.pyaudio, "PyAudio", return_value=audio):
+        yield audio, stream
+
+
+class TestAudioSettings:
+    def test_defaults_match_the_documented_values(self):
+        s = ar.AudioSettings()
+
+        assert (s.channels, s.chunk, s.rate, s.record_seconds) == (
+            1,
+            1024,
+            44100,
+            10,
+        )
+        assert s.input_folder == "recordings"
+        assert s.format == ar.pyaudio.paInt16
+
+    def test_str_and_repr_describe_every_field(self):
+        s = ar.AudioSettings(channels=2)
+
+        assert repr(s) == str(s)
+        assert "channels=2" in str(s)
+        assert "input_folder='recordings'" in str(s)
+
+
+class TestConfig:
+    def test_creates_the_input_folder_when_absent(self, settings):
+        assert not os.path.exists(settings.input_folder)
+
+        ar.Config(settings)
+
+        assert os.path.isdir(settings.input_folder)
+
+    def test_accepts_an_existing_folder(self, tmp_path):
+        existing = tmp_path / "already-here"
+        existing.mkdir()
+
+        ar.Config(ar.AudioSettings(input_folder=str(existing)))
+
+        assert existing.is_dir()
+
+    def test_rejects_an_unsupported_sample_format(self, settings):
+        settings.format = 999
+
+        with pytest.raises(ValueError, match="Invalid audio format"):
+            ar.Config(settings)
+
+    @pytest.mark.parametrize("channels", [0, 3])
+    def test_rejects_channel_counts_outside_mono_or_stereo(
+        self, settings, channels
+    ):
+        settings.channels = channels
+
+        with pytest.raises(ValueError, match="Channels must be"):
+            ar.Config(settings)
+
+    @pytest.mark.parametrize("rate", [7999, 48001])
+    def test_rejects_sample_rates_outside_the_supported_range(
+        self, settings, rate
+    ):
+        settings.rate = rate
+
+        with pytest.raises(ValueError, match="Sample rate must be"):
+            ar.Config(settings)
+
+
+class TestAudioRecorder:
+    def test_generates_a_timestamped_filename_in_the_input_folder(
+        self, settings, fake_audio
+    ):
+        recorder = ar.AudioRecorder(ar.Config(settings))
+
+        path = recorder.generate_output_file()
+
+        assert path.startswith(settings.input_folder)
+        assert path.endswith(".wav")
+        assert "recording_" in os.path.basename(path)
+
+    def test_records_and_writes_a_wav_file(self, settings, fake_audio):
+        _, stream = fake_audio
+        recorder = ar.AudioRecorder(ar.Config(settings))
+
+        recorder.record_audio()
+
+        assert os.path.exists(recorder.output_file_path)
+        assert stream.read.call_count == int(
+            settings.rate / settings.chunk * settings.record_seconds
+        )
+        assert recorder.is_recording is False
+
+    def test_closes_the_stream_and_terminates_the_device(
+        self, settings, fake_audio
+    ):
+        audio, stream = fake_audio
+        recorder = ar.AudioRecorder(ar.Config(settings))
+
+        recorder.record_audio()
+
+        stream.stop_stream.assert_called_once()
+        stream.close.assert_called_once()
+        audio.terminate.assert_called_once()
+
+    def test_returns_early_and_logs_when_the_stream_cannot_open(
+        self, settings, fake_audio, caplog
+    ):
+        audio, _ = fake_audio
+        audio.open.side_effect = OSError("no input device")
+        recorder = ar.AudioRecorder(ar.Config(settings))
+
+        recorder.record_audio()
+
+        assert "Failed to open stream." in caplog.text
+
+    def test_stops_early_once_the_recording_flag_is_cleared(
+        self, settings, fake_audio
+    ):
+        _, stream = fake_audio
+        recorder = ar.AudioRecorder(ar.Config(settings))
+
+        def stop_after_first_chunk(_chunk):
+            recorder.is_recording = False
+            return b"\x00" * 2048
+
+        stream.read.side_effect = stop_after_first_chunk
+        recorder.record_audio()
+
+        assert stream.read.call_count == 1
+
+    def test_logs_when_reading_the_stream_fails(
+        self, settings, fake_audio, caplog
+    ):
+        _, stream = fake_audio
+        stream.read.side_effect = OSError("device disappeared")
+        recorder = ar.AudioRecorder(ar.Config(settings))
+
+        recorder.record_audio()
+
+        assert "Error occurred during recording" in caplog.text
+
+    def test_signal_handler_clears_the_recording_flag(
+        self, settings, fake_audio
+    ):
+        recorder = ar.AudioRecorder(ar.Config(settings))
+        recorder.is_recording = True
+
+        recorder.signal_handler(signal.SIGINT, None)
+
+        assert recorder.is_recording is False
+
+    def test_installs_signal_handlers_on_the_main_thread(
+        self, settings, fake_audio
+    ):
+        recorder = ar.AudioRecorder(ar.Config(settings))
+
+        with patch.object(ar.signal, "signal") as sig:
+            recorder.record_audio()
+
+        assert {c.args[0] for c in sig.call_args_list} == {
+            signal.SIGINT,
+            signal.SIGTERM,
+        }
+
+    def test_warns_instead_of_installing_handlers_off_the_main_thread(
+        self, settings, fake_audio, caplog
+    ):
+        recorder = ar.AudioRecorder(ar.Config(settings))
+        thread = threading.Thread(target=recorder.record_audio)
+
+        thread.start()
+        thread.join()
+
+        assert (
+            "Signal handling can only be set up in the main thread"
+            in caplog.text
+        )
+
+    def test_warns_when_the_recording_is_suspiciously_small(
+        self, settings, fake_audio, caplog
+    ):
+        recorder = ar.AudioRecorder(ar.Config(settings))
+        recorder.output_file_path = os.path.join(
+            settings.input_folder, "tiny.wav"
+        )
+        with open(recorder.output_file_path, "wb") as handle:
+            handle.write(b"short")
+
+        recorder.validate_output_file()
+
+        assert "unusually small" in caplog.text
+
+    def test_logs_when_the_output_file_is_absent(
+        self, settings, fake_audio, caplog
+    ):
+        recorder = ar.AudioRecorder(ar.Config(settings))
+        recorder.output_file_path = os.path.join(
+            settings.input_folder, "never-written.wav"
+        )
+
+        recorder.validate_output_file()
+
+        assert "does not exist" in caplog.text
+
+
+class TestAudioRecorderEntryPoint:
+    def test_accepts_a_settings_instance(self, settings, fake_audio):
+        result = ar.audio_recorder(settings)
+
+        assert result is not None
+        assert os.path.exists(result)
+
+    def test_accepts_a_settings_dictionary(self, tmp_path, fake_audio):
+        result = ar.audio_recorder(
+            {"input_folder": str(tmp_path / "from-dict"), "record_seconds": 1}
+        )
+
+        assert result is not None
+        assert "from-dict" in result
+
+    def test_builds_settings_from_the_environment_by_default(
+        self, clean_env, tmp_path, fake_audio
+    ):
+        clean_env.setenv("INPUT_FOLDER", str(tmp_path / "from-env"))
+        clean_env.setenv("RECORD_SECONDS", "1")
+        clean_env.setenv("CHANNELS", "2")
+        clean_env.setenv("RATE", "16000")
+
+        result = ar.audio_recorder()
+
+        assert "from-env" in result
+
+    def test_returns_none_and_logs_when_settings_are_invalid(
+        self, tmp_path, fake_audio, caplog
+    ):
+        result = ar.audio_recorder(
+            {"input_folder": str(tmp_path / "bad"), "channels": 9}
+        )
+
+        assert result is None
+        assert "Error in audio recorder." in caplog.text

--- a/tests/test_azure_recommendation.py
+++ b/tests/test_azure_recommendation.py
@@ -1,0 +1,329 @@
+# Copyright (C) 2023-2024 Sebastien Rousseau.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for audioanalyser.modules.azure_recommendation.
+
+NOTE: generate_recommendation() calls ``openai.Completion.create``, which was
+removed in openai>=1.0 and raises APIRemovedInV1 against the pinned 1.11.1.
+These tests patch that call, so they cover this module's own logic - prompt
+construction, response unwrapping, persistence - and deliberately do not claim
+the OpenAI request itself works. See test_rejects_the_removed_openai_api below,
+which pins the actual breakage.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import openai
+import pytest
+
+from audioanalyser.modules import azure_recommendation as rec
+
+
+def _completion(text="A summary."):
+    return SimpleNamespace(choices=[SimpleNamespace(text=text)])
+
+
+class TestConfig:
+    def test_reads_settings_and_applies_defaults(self, full_env):
+        config = rec.Config()
+
+        assert config.GPT3_API_KEY == "test-openai-key"
+        assert config.PROMPT_STRATEGY == "default"
+        assert config.PROMPT_LENGTH_RATIO == pytest.approx(0.1)
+        assert config.MAX_OUTPUT_LENGTH == 2048
+        assert config.OUTPUT_TONE == "neutral"
+        assert config.OUTPUT_VOICE == "neutral"
+
+    def test_reads_overrides_from_the_environment(self, full_env, clean_env):
+        clean_env.setenv("PROMPT_STRATEGY", "fixed")
+        clean_env.setenv("PROMPT_LENGTH_RATIO", "0.5")
+        clean_env.setenv("MAX_OUTPUT_LENGTH", "128")
+        clean_env.setenv("OUTPUT_TONE", "formal")
+        clean_env.setenv("OUTPUT_VOICE", "friendly")
+
+        config = rec.Config()
+
+        assert config.PROMPT_STRATEGY == "fixed"
+        assert config.PROMPT_LENGTH_RATIO == pytest.approx(0.5)
+        assert config.MAX_OUTPUT_LENGTH == 128
+
+    def test_rejects_a_transcripts_folder_that_is_not_a_directory(
+        self, full_env, clean_env, tmp_path
+    ):
+        clean_env.setenv("TRANSCRIPTS_FOLDER", str(tmp_path / "absent"))
+
+        with pytest.raises(EnvironmentError, match="TRANSCRIPTS_FOLDER"):
+            rec.Config()
+
+    def test_rejects_a_recommendations_folder_that_is_not_a_directory(
+        self, full_env, clean_env, tmp_path
+    ):
+        clean_env.setenv("RECOMMENDATIONS_FOLDER", str(tmp_path / "absent"))
+
+        with pytest.raises(EnvironmentError, match="RECOMMENDATIONS_FOLDER"):
+            rec.Config()
+
+    @pytest.mark.parametrize("ratio", ["0", "-0.5", "1.5"])
+    def test_rejects_a_prompt_length_ratio_outside_zero_to_one(
+        self, full_env, clean_env, ratio
+    ):
+        clean_env.setenv("PROMPT_LENGTH_RATIO", ratio)
+
+        with pytest.raises(ValueError, match="PROMPT_LENGTH_RATIO"):
+            rec.Config()
+
+    @pytest.mark.parametrize("length", ["0", "-10"])
+    def test_rejects_a_non_positive_max_output_length(
+        self, full_env, clean_env, length
+    ):
+        clean_env.setenv("MAX_OUTPUT_LENGTH", length)
+
+        with pytest.raises(ValueError, match="MAX_OUTPUT_LENGTH"):
+            rec.Config()
+
+
+class TestTranscript:
+    def test_loads_the_file_contents(self, tmp_path):
+        path = tmp_path / "a.txt"
+        path.write_text("hello world")
+
+        assert rec.Transcript(path).text == "hello world"
+
+    def test_iterates_only_over_txt_files(self, tmp_path):
+        (tmp_path / "one.txt").write_text("1")
+        (tmp_path / "skip.md").write_text("no")
+
+        found = [
+            t.path.name for t in rec.Transcript.iter_transcripts(tmp_path)
+        ]
+
+        assert found == ["one.txt"]
+
+
+class TestPromptConstruction:
+    def test_default_strategy_scales_with_the_input_length(self, full_env):
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        # 100 words at ratio 0.1
+        assert generator.calculate_prompt_length(" ".join(["w"] * 100)) == 10
+
+    def test_default_strategy_never_returns_less_than_one(self, full_env):
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        assert generator.calculate_prompt_length("one") == 1
+
+    def test_fixed_strategy_is_capped_by_max_output_length(
+        self, full_env, clean_env
+    ):
+        clean_env.setenv("PROMPT_STRATEGY", "fixed")
+        clean_env.setenv("MAX_OUTPUT_LENGTH", "5")
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        assert generator.calculate_prompt_length(" ".join(["w"] * 100)) == 5
+        assert generator.calculate_prompt_length("one two") == 2
+
+    def test_rejects_an_unknown_strategy(self, full_env, clean_env):
+        clean_env.setenv("PROMPT_STRATEGY", "sideways")
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        with pytest.raises(ValueError, match="Invalid PROMPT_STRATEGY"):
+            generator.calculate_prompt_length("hello")
+
+    @pytest.mark.parametrize(
+        ("tone", "voice", "expected_tone", "expected_voice"),
+        [
+            ("neutral", "neutral", "", ""),
+            (
+                "formal",
+                "professional",
+                "Formal tone:\n\n",
+                "Professional voice:\n\n",
+            ),
+            ("casual", "friendly", "Casual tone:\n\n", "Friendly voice:\n\n"),
+            ("unknown", "unknown", "", ""),
+        ],
+    )
+    def test_tone_and_voice_prompts_map_from_configuration(
+        self, full_env, clean_env, tone, voice, expected_tone, expected_voice
+    ):
+        clean_env.setenv("OUTPUT_TONE", tone)
+        clean_env.setenv("OUTPUT_VOICE", voice)
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        assert generator.get_tone_and_voice_prompts() == (
+            expected_tone,
+            expected_voice,
+        )
+
+    def test_prompt_includes_the_tone_voice_and_source_text(
+        self, full_env, clean_env
+    ):
+        clean_env.setenv("OUTPUT_TONE", "formal")
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        prompt = generator.create_prompt("the customer called about billing")
+
+        assert prompt.startswith("Formal tone:\n\n")
+        assert "the customer called about billing" in prompt
+        assert "executive" in prompt
+
+
+class TestGenerateRecommendation:
+    def test_sends_the_prompt_and_returns_the_stripped_completion(
+        self, full_env, tmp_path
+    ):
+        source = tmp_path / "call.txt"
+        source.write_text("customer wants a refund")
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        with patch.object(openai, "Completion", MagicMock()) as completion:
+            completion.create.return_value = _completion(
+                "  Recommend a refund.  "
+            )
+            result = generator.generate_recommendation(rec.Transcript(source))
+
+        assert result == "Recommend a refund."
+        kwargs = completion.create.call_args.kwargs
+        assert kwargs["engine"] == "gpt-3.5-turbo-instruct"
+        assert kwargs["max_tokens"] == 2048
+        assert "customer wants a refund" in kwargs["prompt"]
+
+    def test_rejects_the_removed_openai_api(self, full_env, tmp_path):
+        """openai>=1.0 removed the Completion resource this module calls.
+
+        Pinned deliberately: while this raises, the -sum/--summary feature
+        cannot work at runtime no matter how the module is configured.
+        """
+        source = tmp_path / "call.txt"
+        source.write_text("hello")
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        with pytest.raises(openai.lib._old_api.APIRemovedInV1):
+            generator.generate_recommendation(rec.Transcript(source))
+
+
+class TestPersistence:
+    def test_save_text_to_file_creates_parents(self, full_env, tmp_path):
+        target = tmp_path / "nested" / "deep" / "out.txt"
+
+        rec.RecommendationsGenerator(rec.Config()).save_text_to_file(
+            target, "content"
+        )
+
+        assert target.read_text() == "content"
+
+    def test_save_data_to_json_creates_parents(self, full_env, tmp_path):
+        target = tmp_path / "nested" / "out.json"
+
+        rec.RecommendationsGenerator(rec.Config()).save_data_to_json(
+            target, {"recommendation": "text"}
+        )
+
+        assert json.loads(target.read_text()) == {"recommendation": "text"}
+
+    def test_insert_data_to_sqlite_creates_the_table_and_rows(
+        self, full_env, tmp_path
+    ):
+        db = tmp_path / "nested" / "out.db"
+
+        rec.RecommendationsGenerator(rec.Config()).insert_data_to_sqlite(
+            db, "recommendations", [("a.txt", "text")]
+        )
+
+        with sqlite3.connect(db) as conn:
+            rows = conn.execute(
+                "SELECT filename, transcription FROM recommendations"
+            ).fetchall()
+        assert rows == [("a.txt", "text")]
+
+
+class TestGenerateRecommendations:
+    def test_writes_txt_json_and_db_for_each_transcript(
+        self, full_env, folders
+    ):
+        (folders["transcripts"] / "call.txt").write_text("customer text")
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        with patch.object(
+            generator, "generate_recommendation", return_value="Do the thing."
+        ):
+            generator.generate_recommendations()
+
+        out = folders["recommendations"]
+        assert (
+            out / "azure_recommendation-call.txt"
+        ).read_text() == "Do the thing."
+        assert json.loads(
+            (out / "azure_recommendation-call.json").read_text()
+        ) == {"recommendation": "Do the thing."}
+        with sqlite3.connect(out / "recommendations.db") as conn:
+            rows = conn.execute(
+                "SELECT filename, transcription FROM recommendations"
+            ).fetchall()
+        assert rows == [("call.txt", "Do the thing.")]
+
+    def test_does_nothing_when_there_are_no_transcripts(
+        self, full_env, folders
+    ):
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        generator.generate_recommendations()
+
+        assert not list(Path(folders["recommendations"]).iterdir())
+
+
+class TestEntryPoint:
+    def test_generates_recommendations_for_the_configured_folder(
+        self, full_env, folders
+    ):
+        (folders["transcripts"] / "call.txt").write_text("customer text")
+
+        with patch.object(
+            rec.RecommendationsGenerator,
+            "generate_recommendation",
+            return_value="Summary.",
+        ):
+            rec.azure_recommendation()
+
+        assert (
+            folders["recommendations"] / "azure_recommendation-call.txt"
+        ).read_text() == "Summary."
+
+    def test_logs_instead_of_raising_when_configuration_is_invalid(
+        self, full_env, clean_env, tmp_path, caplog
+    ):
+        clean_env.setenv("TRANSCRIPTS_FOLDER", str(tmp_path / "absent"))
+
+        rec.azure_recommendation()
+
+        assert "Script execution failed" in caplog.text
+
+    def test_swallows_the_removed_openai_api_error(
+        self, full_env, folders, caplog
+    ):
+        """The removed-API failure is caught and logged, not surfaced.
+
+        This is why the feature fails silently rather than crashing.
+        """
+        (folders["transcripts"] / "call.txt").write_text("customer text")
+
+        rec.azure_recommendation()
+
+        assert "Script execution failed" in caplog.text
+        assert not list(Path(folders["recommendations"]).iterdir())

--- a/tests/test_azure_translator.py
+++ b/tests/test_azure_translator.py
@@ -1,0 +1,253 @@
+# Copyright (C) 2023-2024 Sebastien Rousseau.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for audioanalyser.modules.azure_translator."""
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from audioanalyser.modules import azure_translator as tr
+
+
+def _payload(*pairs):
+    """Build an Azure Translator style response body."""
+    return [
+        {"translations": [{"to": lang, "text": text} for lang, text in pairs]}
+    ]
+
+
+class TestConfig:
+    def test_reads_settings_and_splits_target_languages(self, full_env):
+        config = tr.Config()
+
+        assert config.key == "test-translator-key"
+        assert config.location == "westeurope"
+        assert config.target_languages == ["fr", "es", "de"]
+        assert config.translations_db_table_name == "translations"
+
+    def test_target_languages_is_empty_when_unset(self, full_env, clean_env):
+        clean_env.delenv("TRANSLATIONS_LANGUAGES")
+
+        assert tr.Config().target_languages == []
+
+    @pytest.mark.parametrize(
+        "missing",
+        ["AZURE_TRANSLATOR_KEY", "AZURE_TRANSLATOR_ENDPOINT", "REGION"],
+    )
+    def test_rejects_missing_azure_settings(
+        self, full_env, clean_env, missing
+    ):
+        clean_env.delenv(missing)
+
+        with pytest.raises(ValueError, match="Missing required Azure"):
+            tr.Config()
+
+    def test_rejects_a_transcripts_folder_that_is_not_a_directory(
+        self, full_env, clean_env, tmp_path
+    ):
+        clean_env.setenv("TRANSCRIPTS_FOLDER", str(tmp_path / "absent"))
+
+        with pytest.raises(
+            EnvironmentError, match="Invalid TRANSCRIPTS_FOLDER"
+        ):
+            tr.Config()
+
+    def test_rejects_a_translations_folder_that_is_not_a_directory(
+        self, full_env, clean_env, tmp_path
+    ):
+        clean_env.setenv("TRANSLATIONS_FOLDER", str(tmp_path / "absent"))
+
+        with pytest.raises(
+            EnvironmentError, match="Invalid TRANSLATIONS_FOLDER"
+        ):
+            tr.Config()
+
+    def test_rejects_non_alphabetic_language_codes(self, full_env, clean_env):
+        clean_env.setenv("TRANSLATIONS_LANGUAGES", "fr,es1")
+
+        with pytest.raises(ValueError, match="Invalid language codes"):
+            tr.Config()
+
+
+class TestTranscript:
+    def test_loads_the_file_contents(self, tmp_path):
+        path = tmp_path / "a.txt"
+        path.write_text("hello world")
+
+        assert tr.Transcript(path).text == "hello world"
+
+    def test_returns_empty_string_and_logs_when_unreadable(
+        self, tmp_path, caplog
+    ):
+        missing = tmp_path / "gone.txt"
+
+        assert tr.Transcript(missing).text == ""
+        assert "Error reading file" in caplog.text
+
+    def test_iterates_only_over_txt_files(self, tmp_path):
+        (tmp_path / "one.txt").write_text("1")
+        (tmp_path / "two.txt").write_text("2")
+        (tmp_path / "skip.md").write_text("no")
+
+        found = sorted(
+            t.path.name for t in tr.Transcript.iter_transcripts(tmp_path)
+        )
+
+        assert found == ["one.txt", "two.txt"]
+
+
+class TestTranslator:
+    def test_posts_to_the_translate_endpoint_and_returns_json(self, full_env):
+        response = MagicMock()
+        response.json.return_value = _payload(("fr", "bonjour"))
+
+        with patch.object(requests, "post", return_value=response) as post:
+            result = tr.Translator(tr.Config()).translate("hello", ["fr"])
+
+        assert result == _payload(("fr", "bonjour"))
+        (url,) = post.call_args.args
+        assert url.endswith("/translate")
+        assert post.call_args.kwargs["params"]["to"] == ["fr"]
+        assert post.call_args.kwargs["json"] == [{"text": "hello"}]
+
+    def test_sends_the_subscription_headers(self, full_env):
+        response = MagicMock()
+        response.json.return_value = []
+
+        with patch.object(requests, "post", return_value=response) as post:
+            tr.Translator(tr.Config()).translate("hello", ["fr"])
+
+        headers = post.call_args.kwargs["headers"]
+        assert headers["Ocp-Apim-Subscription-Key"] == "test-translator-key"
+        assert headers["Ocp-Apim-Subscription-Region"] == "westeurope"
+        assert headers["X-ClientTraceId"]
+
+    def test_returns_empty_dict_and_logs_on_request_failure(
+        self, full_env, caplog
+    ):
+        with patch.object(
+            requests, "post", side_effect=requests.RequestException("no route")
+        ):
+            result = tr.Translator(tr.Config()).translate("hello", ["fr"])
+
+        assert result == {}
+        assert "Translation request failed" in caplog.text
+
+    def test_returns_empty_dict_when_the_response_is_an_error_status(
+        self, full_env, caplog
+    ):
+        response = MagicMock()
+        response.raise_for_status.side_effect = requests.HTTPError("401")
+
+        with patch.object(requests, "post", return_value=response):
+            assert tr.Translator(tr.Config()).translate("hello", ["fr"]) == {}
+
+
+class TestWriters:
+    def test_write_to_file_writes_one_line_per_translation(self, tmp_path):
+        out = tmp_path / "out.txt"
+
+        tr.write_to_file(out, ["one", "two"])
+
+        assert out.read_text() == "one\ntwo\n"
+
+    def test_write_to_file_logs_instead_of_raising_when_path_is_bad(
+        self, tmp_path, caplog
+    ):
+        tr.write_to_file(tmp_path / "absent-dir" / "out.txt", ["one"])
+
+        assert "Error writing to file" in caplog.text
+
+    def test_write_to_json_serialises_the_list(self, tmp_path):
+        out = tmp_path / "out.json"
+
+        tr.write_to_json(out, ["one", "two"])
+
+        assert json.loads(out.read_text()) == ["one", "two"]
+
+    def test_write_to_sqlite_creates_the_table_and_rows(self, tmp_path):
+        db = tmp_path / "out.db"
+
+        tr.write_to_sqlite("translations", "a.txt", "fr", ["un", "deux"], db)
+
+        with sqlite3.connect(db) as conn:
+            rows = conn.execute(
+                "SELECT filename, language, translation FROM translations"
+            ).fetchall()
+        assert rows == [("a.txt", "fr", "un"), ("a.txt", "fr", "deux")]
+
+
+class TestSaveTranslation:
+    def test_writes_txt_json_and_db_per_language(self, full_env, folders):
+        source = folders["transcripts"] / "call.txt"
+        source.write_text("hello")
+
+        tr.save_translation(
+            source, _payload(("fr", "bonjour"), ("es", "hola")), tr.Config()
+        )
+
+        out = folders["translations"]
+        assert (out / "call-fr.txt").read_text() == "bonjour\n"
+        assert json.loads((out / "call-es.json").read_text()) == ["hola"]
+        with sqlite3.connect(out / "call-fr.db") as conn:
+            rows = conn.execute(
+                "SELECT translation FROM translations"
+            ).fetchall()
+        assert rows == [("bonjour",)]
+
+
+class TestAzureTranslatorEntryPoint:
+    def test_translates_each_transcript_and_saves_the_result(
+        self, full_env, folders
+    ):
+        (folders["transcripts"] / "one.txt").write_text("hello")
+        response = MagicMock()
+        response.json.return_value = _payload(("fr", "bonjour"))
+
+        with patch.object(requests, "post", return_value=response):
+            tr.azure_translator()
+
+        assert (
+            folders["translations"] / "one-fr.txt"
+        ).read_text() == "bonjour\n"
+
+    def test_explicit_arguments_override_the_configured_languages(
+        self, full_env, folders
+    ):
+        (folders["transcripts"] / "one.txt").write_text("hello")
+        response = MagicMock()
+        response.json.return_value = _payload(("de", "hallo"))
+
+        with patch.object(requests, "post", return_value=response) as post:
+            tr.azure_translator("de")
+
+        assert post.call_args.kwargs["params"]["to"] == ["de"]
+
+    def test_writes_nothing_when_translation_yields_no_result(
+        self, full_env, folders
+    ):
+        (folders["transcripts"] / "one.txt").write_text("hello")
+
+        with patch.object(
+            requests, "post", side_effect=requests.RequestException("down")
+        ):
+            tr.azure_translator()
+
+        assert not list(Path(folders["translations"]).iterdir())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,295 @@
+# Copyright (C) 2023-2024 Sebastien Rousseau.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for the audioanalyser command line interface.
+
+Note the module decorates its module-level functions with @staticmethod. That
+only became callable in Python 3.10, so importing and invoking this CLI is
+impossible on 3.9 - which the package declared support for until recently.
+"""
+
+import asyncio
+import json
+from argparse import Namespace
+from unittest.mock import AsyncMock, patch
+
+from audioanalyser import __main__ as cli
+
+
+def _args(**overrides):
+    defaults = {
+        "speech_to_text": False,
+        "text_analysis": False,
+        "summary": False,
+        "record": None,
+        "text_to_speech": False,
+        "text": "",
+        "name": "",
+        "server": False,
+        "translate": None,
+        "files": [],
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def _run_main(argv):
+    with patch.object(
+        cli.sys if hasattr(cli, "sys") else cli, "argv", create=True
+    ):
+        pass
+    return asyncio.run(cli.main())
+
+
+class TestValidateArgs:
+    def test_accepts_existing_files(self, tmp_path):
+        one = tmp_path / "one.txt"
+        one.write_text("x")
+
+        assert cli.validate_args(_args(files=[str(one)])) is True
+
+    def test_accepts_an_empty_file_list(self):
+        assert cli.validate_args(_args(files=[])) is True
+
+    def test_rejects_a_missing_file_and_logs_it(self, tmp_path, caplog):
+        missing = str(tmp_path / "absent.txt")
+
+        assert cli.validate_args(_args(files=[missing])) is False
+        assert "does not exist" in caplog.text
+
+
+class TestSaveResults:
+    def test_writes_indented_json(self, tmp_path):
+        target = tmp_path / "out.json"
+
+        cli.save_results({"a": 1}, target)
+
+        assert json.loads(target.read_text()) == {"a": 1}
+
+
+class TestLoadAudioSettings:
+    def test_reads_a_settings_file(self, tmp_path):
+        path = tmp_path / "settings.json"
+        path.write_text('{"channels": 2}')
+
+        assert cli.load_audio_settings(path) == {"channels": 2}
+
+    def test_returns_none_and_logs_on_bad_input(self, tmp_path, caplog):
+        assert cli.load_audio_settings(tmp_path / "absent.json") is None
+        assert "Error loading audio settings" in caplog.text
+
+
+class TestProcessSpeechToText:
+    def test_transcribes_the_named_file(self, tmp_path):
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"RIFF")
+        args = _args(text=str(audio), files=[str(audio)])
+
+        with patch.object(cli, "transcribe_audio_files") as transcribe:
+            asyncio.run(cli.process_speech_to_text(args))
+
+        transcribe.assert_called_once_with(str(audio))
+
+    def test_logs_when_no_audio_file_is_given(self, caplog):
+        with patch.object(cli, "transcribe_audio_files") as transcribe:
+            asyncio.run(cli.process_speech_to_text(_args(text="")))
+
+        transcribe.assert_not_called()
+        assert "No audio files specified." in caplog.text
+
+    def test_logs_when_the_referenced_file_is_missing(self, tmp_path, caplog):
+        args = _args(text="something", files=[str(tmp_path / "absent.wav")])
+
+        with patch.object(cli, "transcribe_audio_files") as transcribe:
+            asyncio.run(cli.process_speech_to_text(args))
+
+        transcribe.assert_not_called()
+        assert "No audio files specified." in caplog.text
+
+
+class TestProcessTextAnalysis:
+    def test_analyses_the_given_files(self, tmp_path):
+        one = tmp_path / "one.txt"
+        one.write_text("hello")
+
+        with patch.object(
+            cli, "analyze_text_files", new=AsyncMock()
+        ) as analyse:
+            asyncio.run(cli.process_text_analysis(_args(files=[str(one)])))
+
+        analyse.assert_awaited_once_with([str(one)])
+
+    def test_skips_analysis_when_a_file_is_missing(self, tmp_path):
+        with patch.object(
+            cli, "analyze_text_files", new=AsyncMock()
+        ) as analyse:
+            asyncio.run(
+                cli.process_text_analysis(
+                    _args(files=[str(tmp_path / "absent.txt")])
+                )
+            )
+
+        analyse.assert_not_awaited()
+
+
+class TestProcessTextToSpeech:
+    def test_synthesises_when_text_and_name_are_present(self):
+        args = _args(text="hello", name="greeting")
+
+        with patch.object(cli, "text_to_speech") as tts:
+            asyncio.run(cli.process_text_to_speech(args))
+
+        tts.assert_called_once_with("hello", "greeting")
+
+    def test_logs_when_text_or_name_is_missing(self, caplog):
+        with patch.object(cli, "text_to_speech") as tts:
+            asyncio.run(
+                cli.process_text_to_speech(_args(text="hello", name=""))
+            )
+
+        tts.assert_not_called()
+        assert "Text and name arguments are required" in caplog.text
+
+    def test_skips_when_a_referenced_file_is_missing(self, tmp_path):
+        args = _args(
+            text="hello", name="greeting", files=[str(tmp_path / "absent.txt")]
+        )
+
+        with patch.object(cli, "text_to_speech") as tts:
+            asyncio.run(cli.process_text_to_speech(args))
+
+        tts.assert_not_called()
+
+
+class TestProcessAudioRecording:
+    def test_records_with_defaults(self):
+        with patch.object(cli, "audio_recorder") as recorder:
+            cli.process_audio_recording(_args(record="default"))
+
+        recorder.assert_called_once_with(None)
+
+    def test_records_with_settings_loaded_from_a_file(self, tmp_path):
+        path = tmp_path / "settings.json"
+        path.write_text('{"channels": 2}')
+
+        with patch.object(cli, "audio_recorder") as recorder:
+            cli.process_audio_recording(_args(record=str(path)))
+
+        recorder.assert_called_once_with({"channels": 2})
+
+
+class TestProcessTranslation:
+    def test_translates_with_the_requested_languages(self, tmp_path):
+        one = tmp_path / "one.txt"
+        one.write_text("hello")
+        args = _args(translate=["fr", "de"], files=[str(one)])
+
+        with patch.object(cli, "azure_translator") as translator:
+            cli.process_translation(args)
+
+        translator.assert_called_once_with("fr", "de")
+
+    def test_skips_when_a_referenced_file_is_missing(self, tmp_path):
+        args = _args(translate=["fr"], files=[str(tmp_path / "absent.txt")])
+
+        with patch.object(cli, "azure_translator") as translator:
+            cli.process_translation(args)
+
+        translator.assert_not_called()
+
+
+class TestStartServer:
+    def test_delegates_to_the_server_module(self):
+        with patch.object(cli, "speech_text_server") as server:
+            cli.start_server()
+
+        server.assert_called_once_with()
+
+
+class TestMain:
+    def _main_with(self, argv):
+        with patch("sys.argv", ["audioanalyser", *argv]):
+            asyncio.run(cli.main())
+
+    def test_speech_to_text_flag_dispatches(self, tmp_path):
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"RIFF")
+
+        with patch.object(
+            cli, "process_speech_to_text", new=AsyncMock()
+        ) as handler:
+            self._main_with(["-stt", str(audio)])
+
+        handler.assert_awaited_once()
+
+    def test_text_analysis_flag_dispatches(self):
+        with patch.object(
+            cli, "process_text_analysis", new=AsyncMock()
+        ) as handler:
+            self._main_with(["-ta"])
+
+        handler.assert_awaited_once()
+
+    def test_text_to_speech_flag_dispatches(self):
+        with patch.object(
+            cli, "process_text_to_speech", new=AsyncMock()
+        ) as handler:
+            self._main_with(["-tts", "hello", "greeting"])
+
+        handler.assert_awaited_once()
+
+    def test_summary_flag_dispatches(self):
+        with patch.object(cli, "azure_recommendation") as handler:
+            self._main_with(["-sum"])
+
+        handler.assert_called_once_with()
+
+    def test_server_flag_dispatches(self):
+        with patch.object(cli, "start_server") as handler:
+            self._main_with(["-s"])
+
+        handler.assert_called_once_with()
+
+    def test_record_flag_dispatches(self):
+        with patch.object(cli, "process_audio_recording") as handler:
+            self._main_with(["-rec"])
+
+        handler.assert_called_once()
+
+    def test_translate_flag_dispatches(self):
+        with patch.object(cli, "process_translation") as handler:
+            self._main_with(["-t", "fr"])
+
+        handler.assert_called_once()
+
+    def test_prints_help_when_no_flag_is_given(self, capsys):
+        self._main_with([])
+
+        assert "Audio Analyser CLI" in capsys.readouterr().out
+
+    def test_logs_instead_of_raising_when_a_handler_fails(self, caplog):
+        with patch.object(
+            cli, "start_server", side_effect=RuntimeError("server down")
+        ):
+            self._main_with(["-s"])
+
+        assert "An error occurred: server down" in caplog.text
+
+
+class TestPackageMetadata:
+    def test_exposes_a_version(self):
+        import audioanalyser
+
+        assert audioanalyser.__version__

--- a/tests/test_speech_text_server.py
+++ b/tests/test_speech_text_server.py
@@ -1,0 +1,424 @@
+# Copyright (C) 2023-2024 Sebastien Rousseau.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for audioanalyser.modules.speech_text_server.
+
+The endpoints are ordinary methods - cherrypy's decorators only attach
+attributes - so they are called directly rather than over HTTP.
+"""
+
+import os
+import signal
+from unittest.mock import MagicMock, patch
+
+import cherrypy
+import pytest
+
+from audioanalyser.modules import speech_text_server as sts
+
+
+@pytest.fixture
+def server():
+    return sts.SpeechTextAnalysisServer()
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    """A working directory laid out the way the endpoints expect."""
+    for relative in (
+        "dashboard",
+        "resources/input",
+        "resources/transcripts",
+        "resources/reports",
+        "resources/recommendations",
+        "resources/translations",
+    ):
+        (tmp_path / relative).mkdir(parents=True)
+    (tmp_path / "dashboard" / "index.html").write_text("<h1>dashboard</h1>")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestIndex:
+    def test_serves_the_dashboard_file(self, server, workspace):
+        handle = server.index()
+
+        try:
+            assert handle.read() == "<h1>dashboard</h1>"
+        finally:
+            handle.close()
+
+
+class TestSpeechToTextEndpoint:
+    def test_reports_completion_and_restores_stdout(self, server, workspace):
+        before = sts.sys.stdout
+
+        with patch.object(sts, "transcribe_audio_files") as transcribe:
+            result = server.process_all_speech_to_text()
+
+        transcribe.assert_called_once_with()
+        assert result["result"] == "Processing completed"
+        assert sts.sys.stdout is before
+
+    def test_captures_stdout_as_logs(self, server, workspace):
+        with patch.object(
+            sts, "transcribe_audio_files", side_effect=lambda: print("working")
+        ):
+            result = server.process_all_speech_to_text()
+
+        assert "working" in result["logs"]
+
+    def test_returns_500_on_failure(self, server, workspace):
+        with patch.object(
+            sts, "transcribe_audio_files", side_effect=RuntimeError("boom")
+        ):
+            result = server.process_all_speech_to_text()
+
+        assert cherrypy.response.status == 500
+        assert "error" in result
+
+
+class TestTextToSpeechEndpoint:
+    def test_forwards_every_argument(self, server, workspace):
+        with patch.object(sts, "text_to_speech") as tts:
+            result = server.text_to_speech(
+                "hello", "greeting", "fr-FR", "voice"
+            )
+
+        tts.assert_called_once_with("hello", "greeting", "fr-FR", "voice")
+        assert result["result"] == "Processing completed"
+
+    def test_applies_the_default_language_and_voice(self, server, workspace):
+        with patch.object(sts, "text_to_speech") as tts:
+            server.text_to_speech("hello", "greeting")
+
+        tts.assert_called_once_with(
+            "hello", "greeting", "en-GB", "en-GB-RyanNeural"
+        )
+
+    def test_returns_500_on_failure(self, server, workspace):
+        with patch.object(
+            sts, "text_to_speech", side_effect=ValueError("bad")
+        ):
+            result = server.text_to_speech("hello", "greeting")
+
+        assert cherrypy.response.status == 500
+        assert "error" in result
+
+
+class TestRecordAudioEndpoint:
+    def test_returns_the_recorded_file_path(self, server, workspace):
+        with patch.object(sts, "audio_recorder", return_value="/tmp/a.wav"):
+            result = server.record_audio()
+
+        assert result["recorded_file"] == "/tmp/a.wav"
+        assert result["result"] == "Recording completed"
+
+    def test_returns_500_when_recording_yields_nothing(
+        self, server, workspace
+    ):
+        with patch.object(sts, "audio_recorder", return_value=None):
+            result = server.record_audio()
+
+        assert cherrypy.response.status == 500
+        assert result["error"] == "Failed to record audio."
+
+    def test_returns_500_when_the_recorder_raises(self, server, workspace):
+        with patch.object(
+            sts, "audio_recorder", side_effect=OSError("no device")
+        ):
+            result = server.record_audio()
+
+        assert cherrypy.response.status == 500
+        assert "no device" in result["error"]
+
+
+class TestListAudioFiles:
+    def test_lists_only_wav_files(self, server, workspace):
+        inputs = workspace / "resources" / "input"
+        (inputs / "one.wav").write_bytes(b"RIFF")
+        (inputs / "two.wav").write_bytes(b"RIFF")
+        (inputs / "notes.txt").write_text("skip")
+        (inputs / "nested").mkdir()
+
+        files = server.list_audio_files()
+
+        assert sorted(f["name"] for f in files) == ["one.wav", "two.wav"]
+        assert all(os.path.isabs(f["full_path"]) for f in files)
+
+    def test_returns_500_when_the_folder_is_missing(
+        self, server, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+
+        result = server.list_audio_files()
+
+        assert cherrypy.response.status == 500
+        assert "error" in result
+
+
+class TestServeAndDownload:
+    def test_serve_audio_delegates_to_cherrypy_static(self, server, workspace):
+        (workspace / "resources" / "input" / "a.wav").write_bytes(b"RIFF")
+
+        with patch.object(
+            cherrypy.lib.static, "serve_file", return_value="served"
+        ) as serve:
+            assert server.serve_audio("a.wav") == "served"
+
+        assert serve.call_args.kwargs["content_type"] == "audio/wav"
+
+    def test_serve_audio_returns_500_on_failure(self, server, workspace):
+        with patch.object(
+            cherrypy.lib.static, "serve_file", side_effect=OSError("gone")
+        ):
+            result = server.serve_audio("a.wav")
+
+        assert cherrypy.response.status == 500
+        assert "error" in result
+
+    def test_download_audio_sets_the_attachment_header(
+        self, server, workspace
+    ):
+        with patch.object(
+            cherrypy.lib.static, "serve_file", return_value="served"
+        ) as serve:
+            assert server.download_audio("a.wav") == "served"
+
+        header = cherrypy.response.headers["Content-Disposition"]
+        assert header == 'attachment; filename="a.wav"'
+        assert (
+            serve.call_args.kwargs["content_type"]
+            == "application/octet-stream"
+        )
+
+    def test_download_audio_returns_500_on_failure(self, server, workspace):
+        with patch.object(
+            cherrypy.lib.static, "serve_file", side_effect=OSError("gone")
+        ):
+            result = server.download_audio("a.wav")
+
+        assert cherrypy.response.status == 500
+        assert "error" in result
+
+
+class TestTextAnalysisEndpoint:
+    def test_starts_a_worker_thread(self, server, workspace):
+        with patch.object(sts.threading, "Thread") as thread:
+            result = server.process_text_analysis()
+
+        thread.assert_called_once_with(target=server.run_analysis_thread)
+        thread.return_value.start.assert_called_once()
+        assert result["result"] == "Text analysis process started"
+
+    def test_returns_500_when_the_thread_cannot_start(self, server, workspace):
+        with patch.object(
+            sts.threading, "Thread", side_effect=RuntimeError("no threads")
+        ):
+            result = server.process_text_analysis()
+
+        assert cherrypy.response.status == 500
+        assert "error" in result
+
+    def test_worker_writes_completed_on_success(self, server, workspace):
+        with patch.object(sts.asyncio, "run") as run:
+            server.run_analysis_thread()
+
+        run.assert_called_once()
+        assert (workspace / "analysis_status.txt").read_text() == "Completed"
+
+    def test_worker_writes_the_error_on_failure(self, server, workspace):
+        with patch.object(
+            sts.asyncio, "run", side_effect=RuntimeError("boom")
+        ):
+            server.run_analysis_thread()
+
+        assert (workspace / "analysis_status.txt").read_text() == "Error: boom"
+
+    def test_status_reports_processing_before_the_file_exists(
+        self, server, workspace
+    ):
+        assert server.get_analysis_status() == {"status": "Processing"}
+
+    def test_status_reports_the_file_contents_once_written(
+        self, server, workspace
+    ):
+        (workspace / "analysis_status.txt").write_text("Completed")
+
+        assert server.get_analysis_status() == {"status": "Completed"}
+
+
+class TestListingEndpoints:
+    @pytest.mark.parametrize(
+        ("method", "folder"),
+        [
+            ("get_transcripts_list", "resources/transcripts"),
+            ("get_reports_list", "resources/reports"),
+            ("get_summaries_list", "resources/recommendations"),
+            ("get_translations_list", "resources/translations"),
+        ],
+    )
+    def test_returns_filename_and_content_for_each_txt_file(
+        self, server, workspace, method, folder
+    ):
+        (workspace / folder / "one.txt").write_text("content one")
+        (workspace / folder / "skip.md").write_text("ignored")
+
+        items = getattr(server, method)()
+
+        assert items == [{"filename": "one.txt", "content": "content one"}]
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "get_transcripts_list",
+            "get_reports_list",
+            "get_summaries_list",
+            "get_translations_list",
+        ],
+    )
+    def test_returns_an_empty_list_when_the_folder_is_absent(
+        self, server, tmp_path, monkeypatch, method
+    ):
+        monkeypatch.chdir(tmp_path)
+
+        assert getattr(server, method)() == []
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "get_transcripts_list",
+            "get_reports_list",
+            "get_summaries_list",
+            "get_translations_list",
+        ],
+    )
+    def test_returns_500_when_a_file_cannot_be_read(
+        self, server, workspace, method
+    ):
+        folder = {
+            "get_transcripts_list": "resources/transcripts",
+            "get_reports_list": "resources/reports",
+            "get_summaries_list": "resources/recommendations",
+            "get_translations_list": "resources/translations",
+        }[method]
+        (workspace / folder / "one.txt").write_text("content")
+
+        with patch("builtins.open", side_effect=IOError("unreadable")):
+            result = getattr(server, method)()
+
+        assert cherrypy.response.status == 500
+        assert "error" in result
+
+
+class TestRecommendationsEndpoint:
+    def test_starts_a_worker_thread(self, server, workspace):
+        with patch.object(sts.threading, "Thread") as thread:
+            result = server.generate_recommendations()
+
+        thread.assert_called_once_with(
+            target=server.run_recommendations_thread
+        )
+        assert result["result"] == "Process started"
+
+    def test_returns_500_when_the_thread_cannot_start(self, server, workspace):
+        with patch.object(
+            sts.threading, "Thread", side_effect=RuntimeError("no threads")
+        ):
+            result = server.generate_recommendations()
+
+        assert cherrypy.response.status == 500
+        assert "error" in result
+
+    def test_worker_writes_completed_on_success(self, server, workspace):
+        with patch.object(sts.asyncio, "run"):
+            server.run_recommendations_thread()
+
+        assert (
+            workspace / "recommendations_status.txt"
+        ).read_text() == "Completed"
+
+    def test_worker_writes_the_error_on_failure(self, server, workspace):
+        with patch.object(
+            sts.asyncio, "run", side_effect=RuntimeError("boom")
+        ):
+            server.run_recommendations_thread()
+
+        status = (workspace / "recommendations_status.txt").read_text()
+        assert status == "Error: boom"
+
+
+class TestTranslationEndpoint:
+    def test_starts_a_worker_thread_with_the_country_code(
+        self, server, workspace
+    ):
+        with patch.object(
+            cherrypy, "request", MagicMock(json={"countryCode": "fr"})
+        ):
+            with patch.object(sts.threading, "Thread") as thread:
+                result = server.process_all_translations()
+
+        assert thread.call_args.kwargs["args"] == ("fr",)
+        assert result["result"] == "Translation process started: fr"
+
+    def test_returns_an_error_when_the_body_is_unusable(
+        self, server, workspace
+    ):
+        broken = MagicMock()
+        type(broken).json = property(
+            lambda self: (_ for _ in ()).throw(ValueError("no body"))
+        )
+
+        with patch.object(cherrypy, "request", broken):
+            result = server.process_all_translations()
+
+        assert result[0]["error"]
+        assert result[1] == 500
+
+    def test_worker_calls_the_translator(self, server, workspace):
+        with patch.object(sts, "azure_translator") as translator:
+            server.run_translation_thread("fr")
+
+        translator.assert_called_once_with("fr")
+
+    def test_worker_logs_instead_of_raising(self, server, workspace):
+        with patch.object(
+            sts, "azure_translator", side_effect=RuntimeError("boom")
+        ):
+            server.run_translation_thread("fr")  # must not raise
+
+
+class TestServerLifecycle:
+    def test_graceful_shutdown_exits_the_engine(self, capsys):
+        with patch.object(cherrypy.engine, "exit") as engine_exit:
+            sts.graceful_shutdown(signal.SIGINT, None)
+
+        engine_exit.assert_called_once()
+        assert "Shutting down server" in capsys.readouterr().out
+
+    def test_speech_text_server_configures_and_starts_cherrypy(self):
+        with patch.object(cherrypy, "quickstart") as quickstart:
+            with patch.object(cherrypy.config, "update") as config_update:
+                with patch.object(sts.signal, "signal") as sig:
+                    sts.speech_text_server()
+
+        config_update.assert_called_once_with({"server.socket_port": 8080})
+        sig.assert_called_once_with(signal.SIGINT, sts.graceful_shutdown)
+
+        root, mount, config = quickstart.call_args.args
+        assert isinstance(root, sts.SpeechTextAnalysisServer)
+        assert mount == "/"
+        assert config["/"]["tools.staticdir.index"] == "index.html"
+        assert config["/"]["tools.staticdir.dir"].endswith("dashboard")

--- a/tests/test_text_to_speech.py
+++ b/tests/test_text_to_speech.py
@@ -1,0 +1,220 @@
+# Copyright (C) 2023-2024 Sebastien Rousseau.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for audioanalyser.modules.text_to_speech."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from audioanalyser.modules import text_to_speech as tts
+
+
+class TestConfig:
+    def test_reads_every_setting_from_the_environment(self, full_env):
+        config = tts.Config()
+
+        assert config.api_key == "test-speech-key"
+        assert config.region == "westeurope"
+        assert config.OUTPUT_FOLDER == full_env["RECORDS_FOLDER"]
+        assert config.audio_extension == ".wav"
+
+    def test_audio_extension_defaults_to_wav(self, full_env, clean_env):
+        clean_env.delenv("AUDIO_EXTENSION")
+
+        assert tts.Config().audio_extension == "wav"
+
+    @pytest.mark.parametrize(
+        "missing",
+        ["AZURE_AUDIO_TEXT_KEY", "REGION", "RECORDS_FOLDER"],
+    )
+    def test_raises_when_a_required_variable_is_absent(
+        self, full_env, clean_env, missing
+    ):
+        clean_env.delenv(missing)
+
+        with pytest.raises(EnvironmentError, match="Missing required"):
+            tts.Config()
+
+    def test_names_the_missing_variables_in_the_log(
+        self, full_env, clean_env, caplog
+    ):
+        clean_env.delenv("REGION")
+
+        with pytest.raises(EnvironmentError):
+            tts.Config()
+
+        assert "region" in caplog.text
+
+
+class TestTextToSpeech:
+    def _synthesizer(self, reason, audio=b"", error_details=None):
+        result = MagicMock()
+        result.reason = reason
+        result.audio_data = audio
+        result.error_details = error_details
+        synth = MagicMock()
+        synth.speak_text_async.return_value.get.return_value = result
+        return synth
+
+    def test_returns_audio_data_when_synthesis_completes(self, full_env):
+        completed = tts.speechsdk.ResultReason.SynthesizingAudioCompleted
+        synth = self._synthesizer(completed, audio=b"RIFFDATA")
+
+        with patch.object(
+            tts.speechsdk, "SpeechSynthesizer", return_value=synth
+        ):
+            with patch.object(tts.speechsdk, "SpeechConfig"):
+                result = tts.TextToSpeech(tts.Config()).synthesize_text(
+                    "hello"
+                )
+
+        assert result == b"RIFFDATA"
+        synth.speak_text_async.assert_called_once_with("hello")
+
+    def test_passes_language_and_voice_to_the_speech_config(self, full_env):
+        completed = tts.speechsdk.ResultReason.SynthesizingAudioCompleted
+        synth = self._synthesizer(completed, audio=b"x")
+        speech_config = MagicMock()
+
+        with patch.object(
+            tts.speechsdk, "SpeechSynthesizer", return_value=synth
+        ):
+            with patch.object(
+                tts.speechsdk, "SpeechConfig", return_value=speech_config
+            ):
+                tts.TextToSpeech(tts.Config()).synthesize_text(
+                    "hi", language="fr-FR", voice_name="fr-FR-DeniseNeural"
+                )
+
+        assert speech_config.speech_synthesis_language == "fr-FR"
+        assert (
+            speech_config.speech_synthesis_voice_name == "fr-FR-DeniseNeural"
+        )
+
+    def test_returns_none_and_logs_the_reason_on_failure(
+        self, full_env, caplog
+    ):
+        synth = self._synthesizer(
+            tts.speechsdk.ResultReason.Canceled, error_details="quota exceeded"
+        )
+
+        with patch.object(
+            tts.speechsdk, "SpeechSynthesizer", return_value=synth
+        ):
+            with patch.object(tts.speechsdk, "SpeechConfig"):
+                result = tts.TextToSpeech(tts.Config()).synthesize_text(
+                    "hello"
+                )
+
+        assert result is None
+        assert "quota exceeded" in caplog.text
+
+    def test_reports_unknown_error_when_no_details_are_supplied(
+        self, full_env, caplog
+    ):
+        synth = self._synthesizer(
+            tts.speechsdk.ResultReason.Canceled, error_details=None
+        )
+
+        with patch.object(
+            tts.speechsdk, "SpeechSynthesizer", return_value=synth
+        ):
+            with patch.object(tts.speechsdk, "SpeechConfig"):
+                result = tts.TextToSpeech(tts.Config()).synthesize_text(
+                    "hello"
+                )
+
+        assert result is None
+        assert "Unknown error." in caplog.text
+
+    def test_reraises_when_the_sdk_itself_fails(self, full_env, caplog):
+        with patch.object(
+            tts.speechsdk, "SpeechConfig", side_effect=RuntimeError("boom")
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                tts.TextToSpeech(tts.Config()).synthesize_text("hello")
+
+        assert "An error occurred during speech synthesis" in caplog.text
+
+
+class TestTextToSpeechEntryPoint:
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"text": "", "name": "n"}, "Text must be"),
+            ({"text": None, "name": "n"}, "Text must be"),
+            ({"text": 42, "name": "n"}, "Text must be"),
+            ({"text": "t", "name": ""}, "Name must be"),
+            ({"text": "t", "name": 7}, "Name must be"),
+            ({"text": "t", "name": "n", "language": ""}, "Language must be"),
+            ({"text": "t", "name": "n", "language": 1}, "Language must be"),
+            (
+                {"text": "t", "name": "n", "voice_name": ""},
+                "Voice name must be",
+            ),
+            (
+                {"text": "t", "name": "n", "voice_name": 1},
+                "Voice name must be",
+            ),
+        ],
+    )
+    def test_rejects_invalid_arguments(self, kwargs, message):
+        with pytest.raises(ValueError, match=message):
+            tts.text_to_speech(**kwargs)
+
+    def test_writes_the_audio_file_to_the_output_folder(self, full_env):
+        with patch.object(
+            tts.TextToSpeech, "synthesize_text", return_value=b"AUDIO"
+        ):
+            tts.text_to_speech("hello", "greeting")
+
+        written = Path(full_env["RECORDS_FOLDER"]) / "greeting.wav"
+        assert written.read_bytes() == b"AUDIO"
+
+    def test_creates_the_output_folder_when_it_is_missing(
+        self, full_env, clean_env, tmp_path
+    ):
+        target = tmp_path / "not-yet-created"
+        clean_env.setenv("RECORDS_FOLDER", str(target))
+
+        with patch.object(
+            tts.TextToSpeech, "synthesize_text", return_value=b"AUDIO"
+        ):
+            tts.text_to_speech("hello", "greeting")
+
+        assert (target / "greeting.wav").read_bytes() == b"AUDIO"
+
+    def test_writes_nothing_when_synthesis_returns_no_audio(
+        self, full_env, caplog
+    ):
+        with patch.object(
+            tts.TextToSpeech, "synthesize_text", return_value=None
+        ):
+            tts.text_to_speech("hello", "greeting")
+
+        assert not list(Path(full_env["RECORDS_FOLDER"]).iterdir())
+        assert "No audio data received" in caplog.text
+
+    def test_reraises_and_logs_when_configuration_is_invalid(
+        self, full_env, clean_env, caplog
+    ):
+        clean_env.delenv("REGION")
+
+        with pytest.raises(EnvironmentError):
+            tts.text_to_speech("hello", "greeting")
+
+        assert "Script execution failed" in caplog.text

--- a/tests/test_transcribe_audio_files.py
+++ b/tests/test_transcribe_audio_files.py
@@ -1,0 +1,298 @@
+# Copyright (C) 2023-2024 Sebastien Rousseau.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for audioanalyser.modules.transcribe_audio_files."""
+
+import json
+import logging
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from audioanalyser.modules import transcribe_audio_files as taf
+
+
+@pytest.fixture
+def env(full_env, clean_env):
+    """full_env plus the table name this module needs."""
+    clean_env.setenv("TRANSCRIPTS_DB_TABLE_NAME", "transcripts")
+    return full_env
+
+
+def _recognizer(results=("hello world",), *, stop=True):
+    """Build a recognizer whose callbacks fire when recognition starts."""
+    recognizer = MagicMock()
+    handlers = {}
+
+    for name in ("recognized", "canceled", "session_stopped"):
+        getattr(recognizer, name).connect.side_effect = (
+            lambda fn, key=name: handlers.__setitem__(key, fn)
+        )
+
+    def start():
+        for text in results:
+            event = MagicMock()
+            event.result.text = text
+            handlers["recognized"](event)
+        if stop:
+            handlers["session_stopped"](MagicMock())
+
+    recognizer.start_continuous_recognition.side_effect = start
+    recognizer._handlers = handlers
+    return recognizer
+
+
+class TestConfig:
+    def test_reads_every_setting_from_the_environment(self, env):
+        config = taf.Config()
+
+        assert config.api_key == "test-speech-key"
+        assert config.region == "westeurope"
+        assert config.transcripts_db_table_name == "transcripts"
+
+    @pytest.mark.parametrize(
+        "missing",
+        [
+            "AZURE_AUDIO_TEXT_KEY",
+            "REGION",
+            "INPUT_FOLDER",
+            "TRANSCRIPTS_FOLDER",
+            "TRANSCRIPTS_DB_TABLE_NAME",
+        ],
+    )
+    def test_raises_when_a_required_variable_is_absent(
+        self, env, clean_env, missing
+    ):
+        clean_env.delenv(missing)
+
+        with pytest.raises(EnvironmentError, match="Missing required"):
+            taf.Config()
+
+
+class TestSpeechToTextRecognition:
+    def test_collects_every_recognised_phrase(self, env):
+        recognizer = _recognizer(("first", "second"))
+
+        with patch.object(
+            taf.speechsdk, "SpeechRecognizer", return_value=recognizer
+        ):
+            with patch.object(taf.speechsdk, "SpeechConfig"):
+                with patch.object(taf.speechsdk.audio, "AudioConfig"):
+                    results = taf.SpeechToText(
+                        taf.Config()
+                    ).speech_to_text_long("a.wav")
+
+        assert results == ["first", "second"]
+
+    def test_warns_when_nothing_is_recognised(self, env, caplog):
+        recognizer = _recognizer(())
+
+        with patch.object(
+            taf.speechsdk, "SpeechRecognizer", return_value=recognizer
+        ):
+            with patch.object(taf.speechsdk, "SpeechConfig"):
+                with patch.object(taf.speechsdk.audio, "AudioConfig"):
+                    results = taf.SpeechToText(
+                        taf.Config()
+                    ).speech_to_text_long("a.wav")
+
+        assert results == []
+        assert "No results for a.wav" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("reason", "expected"),
+        [
+            ("EndOfStream", "End of audio stream reached"),
+            ("Error", "Recognition canceled due to an error"),
+            ("other", "Recognition canceled: Reason="),
+        ],
+    )
+    def test_cancellation_paths_are_logged(
+        self, env, caplog, reason, expected
+    ):
+        # The EndOfStream branch logs at INFO, below caplog's
+        # default threshold.
+        caplog.set_level(logging.INFO)
+        recognizer = _recognizer((), stop=False)
+
+        def start():
+            event = MagicMock()
+            event.result.reason = taf.speechsdk.ResultReason.Canceled
+            details = event.result.cancellation_details
+            details.error_details = "boom"
+            if reason == "EndOfStream":
+                details.reason = taf.speechsdk.CancellationReason.EndOfStream
+            elif reason == "Error":
+                details.reason = taf.speechsdk.CancellationReason.Error
+            else:
+                details.reason = "SomethingElse"
+            recognizer._handlers["canceled"](event)
+
+        recognizer.start_continuous_recognition.side_effect = start
+
+        with patch.object(
+            taf.speechsdk, "SpeechRecognizer", return_value=recognizer
+        ):
+            with patch.object(taf.speechsdk, "SpeechConfig"):
+                with patch.object(taf.speechsdk.audio, "AudioConfig"):
+                    taf.SpeechToText(taf.Config()).speech_to_text_long("a.wav")
+
+        assert expected in caplog.text
+
+    def test_non_cancellation_errors_are_logged(self, env, caplog):
+        recognizer = _recognizer((), stop=False)
+
+        def start():
+            event = MagicMock()
+            event.result.reason = "NoMatch"
+            recognizer._handlers["canceled"](event)
+
+        recognizer.start_continuous_recognition.side_effect = start
+
+        with patch.object(
+            taf.speechsdk, "SpeechRecognizer", return_value=recognizer
+        ):
+            with patch.object(taf.speechsdk, "SpeechConfig"):
+                with patch.object(taf.speechsdk.audio, "AudioConfig"):
+                    taf.SpeechToText(taf.Config()).speech_to_text_long("a.wav")
+
+        assert "Recognition error" in caplog.text
+
+
+class TestWriters:
+    def test_write_to_file_writes_one_line_per_result(self, env, tmp_path):
+        out = tmp_path / "a.txt"
+
+        taf.SpeechToText(taf.Config()).write_to_file(out, ["one", "two"])
+
+        assert out.read_text() == "one\ntwo\n"
+
+    def test_write_to_json_serialises_the_results(self, env, tmp_path):
+        out = tmp_path / "a.json"
+
+        taf.SpeechToText(taf.Config()).write_to_json(out, ["one"])
+
+        assert json.loads(out.read_text()) == ["one"]
+
+    def test_write_to_sqlite_creates_the_table_and_rows(self, env, tmp_path):
+        db = tmp_path / "a.db"
+
+        taf.SpeechToText(taf.Config()).write_to_sqlite(db, "a.wav", ["one"])
+
+        with sqlite3.connect(db) as conn:
+            rows = conn.execute(
+                "SELECT filename, transcription FROM transcripts"
+            ).fetchall()
+        assert rows == [("a.wav", "one")]
+
+
+class TestProcessing:
+    def test_process_file_writes_all_three_outputs(self, env, folders):
+        audio = folders["input"] / "call.wav"
+        audio.write_bytes(b"RIFF")
+        processor = taf.SpeechToText(taf.Config())
+
+        with patch.object(
+            processor, "speech_to_text_long", return_value=["hello"]
+        ):
+            processor.process_file(str(audio))
+
+        assert (folders["transcripts"] / "call.txt").read_text() == "hello\n"
+        assert json.loads(
+            (folders["transcripts"] / "call.json").read_text()
+        ) == ["hello"]
+        assert (folders["transcripts"] / "transcriptions.db").exists()
+
+    def test_process_file_writes_nothing_when_there_are_no_results(
+        self, env, folders
+    ):
+        audio = folders["input"] / "call.wav"
+        audio.write_bytes(b"RIFF")
+        processor = taf.SpeechToText(taf.Config())
+
+        with patch.object(processor, "speech_to_text_long", return_value=[]):
+            processor.process_file(str(audio))
+
+        assert not list(folders["transcripts"].iterdir())
+
+    def test_processes_a_single_named_file(self, env, folders):
+        audio = folders["input"] / "one.wav"
+        audio.write_bytes(b"RIFF")
+        processor = taf.SpeechToText(taf.Config())
+
+        with patch.object(processor, "process_file") as process_file:
+            processor.process_audio_files(str(audio))
+
+        process_file.assert_called_once_with(str(audio))
+
+    def test_logs_when_the_named_file_is_missing(self, env, folders, caplog):
+        processor = taf.SpeechToText(taf.Config())
+
+        processor.process_audio_files(str(folders["input"] / "absent.wav"))
+
+        assert "File not found" in caplog.text
+
+    def test_processes_every_matching_file_in_the_input_folder(
+        self, env, folders
+    ):
+        (folders["input"] / "a.wav").write_bytes(b"RIFF")
+        (folders["input"] / "b.wav").write_bytes(b"RIFF")
+        (folders["input"] / "notes.txt").write_text("skip me")
+        processor = taf.SpeechToText(taf.Config())
+
+        with patch.object(processor, "process_file") as process_file:
+            processor.process_audio_files()
+
+        processed = sorted(
+            c.args[0].rsplit("/", 1)[-1] for c in process_file.call_args_list
+        )
+        assert processed == ["a.wav", "b.wav"]
+
+    def test_logs_when_a_listed_file_vanishes_before_processing(
+        self, env, folders, caplog
+    ):
+        # os.listdir sees the file but it is gone by the time it is opened.
+        (folders["input"] / "ghost.wav").write_bytes(b"RIFF")
+        processor = taf.SpeechToText(taf.Config())
+
+        with patch.object(taf.os.path, "exists", return_value=False):
+            with patch.object(processor, "process_file") as process_file:
+                processor.process_audio_files()
+
+        process_file.assert_not_called()
+        assert "File not found" in caplog.text
+
+
+class TestEntryPoint:
+    def test_transcribes_the_requested_file(self, env, folders):
+        audio = folders["input"] / "call.wav"
+        audio.write_bytes(b"RIFF")
+
+        with patch.object(
+            taf.SpeechToText, "speech_to_text_long", return_value=["hi"]
+        ):
+            taf.transcribe_audio_files(str(audio))
+
+        assert (folders["transcripts"] / "call.txt").read_text() == "hi\n"
+
+    def test_logs_instead_of_raising_when_configuration_is_invalid(
+        self, env, clean_env, caplog
+    ):
+        clean_env.delenv("REGION")
+
+        taf.transcribe_audio_files()
+
+        assert "Script execution failed" in caplog.text


### PR DESCRIPTION
The package had no tests — `tests/` held only `__init__.py`, and the pytest and Codecov steps in `ci.yml` were commented out, so the "pytest" job merely installed dependencies. This adds **216 tests reaching 100% statement and branch coverage** and turns that job into a real one.

| module | stmts | cover |
|---|---:|---:|
| `speech_text_server` | 237 | 100% |
| `analyze_text_files` | 116 | 100% |
| `audio_recorder` | 108 | 100% |
| `azure_translator` | 106 | 100% |
| `transcribe_audio_files` | 103 | 100% |
| `azure_recommendation` | 102 | 100% |
| `__main__` | 94 | 100% |
| `text_to_speech` | 67 | 100% |

**The pytest config was broken too.** `pyproject.toml` declared `[tool.pytest]` instead of `[tool.pytest.ini_options]`, with `addopts` as a string — modern pytest **aborts before collecting anything** on that — and demanded `--cov-fail-under=100` against a suite that did not exist. Now the correct table, a list, and a 95% floor.

**Two import-time obstacles**, handled in `conftest.py`:
- `audio_recorder` imports `pyaudio`, which needs the PortAudio system library and **is declared in no manifest**. A stub keeps the suite runnable anywhere.
- `transcribe_audio_files` reads `AUDIO_EXTENSION` at import time, so it is set at conftest module scope.

Fixtures clear all 26 environment variables the package reads and repoint folder settings at `tmp_path`, so real credentials or a stray `.env` cannot influence a result.

**Verified the suite fails when the code is wrong**, not merely that it passes: inverting the language-code validation in `azure_translator` fails 11 tests; skipping the audio write in `text_to_speech` fails 2. Checked on Python 3.10 (CI's version); flake8 clean across the repo.

Two genuine defects surfaced and are **reported, not fixed here** — see the review comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)