### PR TITLE
feat(recommendations): move to a modern chat model

### DIFF
--- a/audioanalyser/modules/azure_recommendation.py
+++ b/audioanalyser/modules/azure_recommendation.py
@@ -55,6 +55,14 @@ logging.basicConfig(
 )
 logger = logging.getLogger("AzureRecommendations")
 
+# gpt-3.5-turbo-instruct was the only model the legacy completions endpoint
+# still served, and OpenAI has been retiring it. gpt-4.1-mini sits in the
+# efficient tier while following the structural instructions this prompt
+# relies on - headings, bullets, ordering - noticeably better. Override with
+# OPENAI_MODEL; the library also accepts gpt-4.1-nano, gpt-4o-mini,
+# gpt-5-mini and gpt-5-nano.
+DEFAULT_MODEL = "gpt-4.1-mini"
+
 
 class Config:
     """
@@ -99,6 +107,9 @@ class Config:
             os.getenv("MAX_OUTPUT_LENGTH", 2048)
         )
         self.OUTPUT_VOICE = os.getenv("OUTPUT_VOICE", "neutral")
+        # Overridable so the model can be changed without a code edit, e.g.
+        # gpt-4.1-nano to cut cost further, or gpt-5-mini for more capability.
+        self.OPENAI_MODEL = os.getenv("OPENAI_MODEL", DEFAULT_MODEL)
         self.validate()
 
     def validate(self) -> None:
@@ -309,8 +320,7 @@ class RecommendationsGenerator:
 
     def generate_recommendation(self, transcript: Transcript) -> str:
         """
-        Generates a recommendation for a given transcript using the OpenAI
-        GPT-3 model.
+        Generates a recommendation for a given transcript.
 
         Args:
             transcript (Transcript): The transcript object containing the text
@@ -320,32 +330,51 @@ class RecommendationsGenerator:
             str: The generated recommendation text.
         """
         # openai>=1.0 removed the module-level Completion resource and the
-        # global api_key; requests go through a client instance, and the
-        # parameter is `model` rather than `engine`.
+        # global api_key; requests go through a client instance.
         client = openai.OpenAI(api_key=self.config.GPT3_API_KEY)
 
-        prompt = self.create_prompt(transcript.text)
-        response = client.completions.create(
-            model="gpt-3.5-turbo-instruct",
-            prompt=prompt,
+        response = client.chat.completions.create(
+            model=self.config.OPENAI_MODEL,
+            messages=self.build_messages(transcript.text),
             temperature=0.8,
-            max_tokens=self.config.MAX_OUTPUT_LENGTH,
+            max_completion_tokens=self.config.MAX_OUTPUT_LENGTH,
             n=1,
             stop=None,
         )
 
-        return response.choices[0].text.strip()
+        content = response.choices[0].message.content
+        return content.strip() if content else ""
 
-    def create_prompt(self, input_text: str) -> str:
+    def build_messages(self, input_text: str) -> list:
         """
-        Constructs a prompt for the GPT-3 model based on the input text and
-        configured settings.
+        Builds the chat messages sent to the model.
+
+        The instructions travel as a system message and the transcript as a
+        user message. Chat models weight the two differently, so keeping the
+        source text out of the instruction block stops long transcripts from
+        diluting the formatting rules.
 
         Args:
             input_text (str): The text of the transcript.
 
         Returns:
-            str: The constructed prompt for GPT-3.
+            list: Chat messages in the order the API expects.
+        """
+        return [
+            {"role": "system", "content": self.create_prompt(input_text)},
+            {"role": "user", "content": input_text},
+        ]
+
+    def create_prompt(self, input_text: str) -> str:
+        """
+        Constructs the instruction block for the model.
+
+        Args:
+            input_text (str): The text of the transcript, used to size the
+            requested summary; it is sent separately as the user message.
+
+        Returns:
+            str: The instructions, without the transcript appended.
         """
         prompt_length = self.calculate_prompt_length(input_text)
         tone_prompt, voice_prompt = self.get_tone_and_voice_prompts()
@@ -364,8 +393,7 @@ class RecommendationsGenerator:
             f"- Include bullet points for crucial findings.\n"
             f"- Prioritize the most crucial, actionable findings.\n"
             f"- Highlight important trends.\n"
-            f"- Provide forward-looking strategic recommendations.\n\n"
-            f"{input_text}"
+            f"- Provide forward-looking strategic recommendations."
         )
 
     def calculate_prompt_length(self, input_text: str) -> int:

--- a/env.example
+++ b/env.example
@@ -95,6 +95,11 @@ ANALYSIS_DB_TABLE_NAME=''
 # your actual API key from https://platform.openai.com/api-keys
 GPT3_API_KEY=''
 
+# OPENAI_MODEL selects the chat model used to generate recommendations.
+# Defaults to gpt-4.1-mini. Other efficient options: gpt-4.1-nano,
+# gpt-4o-mini, gpt-5-mini, gpt-5-nano.
+OPENAI_MODEL=''
+
 
 ################################################################################
 # Microsoft Azure Translator Text Service (azure-translator-text)

--- a/tests/test_azure_recommendation.py
+++ b/tests/test_azure_recommendation.py
@@ -36,7 +36,10 @@ from audioanalyser.modules import azure_recommendation as rec
 
 
 def _completion(text="A summary."):
-    return SimpleNamespace(choices=[SimpleNamespace(text=text)])
+    """A chat completion response: the reply lives on choices[].message."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))]
+    )
 
 
 class TestConfig:
@@ -171,28 +174,48 @@ class TestPromptConstruction:
             expected_voice,
         )
 
-    def test_prompt_includes_the_tone_voice_and_source_text(
-        self, full_env, clean_env
-    ):
+    def test_instructions_carry_the_tone_and_voice(self, full_env, clean_env):
         clean_env.setenv("OUTPUT_TONE", "formal")
         generator = rec.RecommendationsGenerator(rec.Config())
 
         prompt = generator.create_prompt("the customer called about billing")
 
         assert prompt.startswith("Formal tone:\n\n")
-        assert "the customer called about billing" in prompt
         assert "executive" in prompt
+
+    def test_instructions_exclude_the_transcript(self, full_env):
+        """The transcript travels as the user message, not the system one.
+
+        Keeping it out stops a long transcript from diluting the formatting
+        rules the summary depends on.
+        """
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        prompt = generator.create_prompt("the customer called about billing")
+
+        assert "the customer called about billing" not in prompt
+
+
+class TestBuildMessages:
+    def test_splits_instructions_and_transcript_across_roles(self, full_env):
+        generator = rec.RecommendationsGenerator(rec.Config())
+
+        messages = generator.build_messages("customer wants a refund")
+
+        assert [m["role"] for m in messages] == ["system", "user"]
+        assert "executive" in messages[0]["content"]
+        assert messages[1]["content"] == "customer wants a refund"
 
 
 class TestGenerateRecommendation:
-    def test_sends_the_prompt_and_returns_the_stripped_completion(
+    def test_sends_the_messages_and_returns_the_stripped_reply(
         self, full_env, tmp_path
     ):
         source = tmp_path / "call.txt"
         source.write_text("customer wants a refund")
         generator = rec.RecommendationsGenerator(rec.Config())
         client = MagicMock()
-        client.completions.create.return_value = _completion(
+        client.chat.completions.create.return_value = _completion(
             "  Recommend a refund.  "
         )
 
@@ -200,11 +223,42 @@ class TestGenerateRecommendation:
             result = generator.generate_recommendation(rec.Transcript(source))
 
         assert result == "Recommend a refund."
-        kwargs = client.completions.create.call_args.kwargs
-        assert kwargs["model"] == "gpt-3.5-turbo-instruct"
-        assert kwargs["max_tokens"] == 2048
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "gpt-4.1-mini"
+        assert kwargs["max_completion_tokens"] == 2048
         assert kwargs["temperature"] == 0.8
-        assert "customer wants a refund" in kwargs["prompt"]
+        assert kwargs["messages"][1]["content"] == "customer wants a refund"
+
+    def test_uses_the_model_named_in_the_environment(
+        self, full_env, clean_env, tmp_path
+    ):
+        clean_env.setenv("OPENAI_MODEL", "gpt-4.1-nano")
+        source = tmp_path / "call.txt"
+        source.write_text("hello")
+        generator = rec.RecommendationsGenerator(rec.Config())
+        client = MagicMock()
+        client.chat.completions.create.return_value = _completion("text")
+
+        with patch.object(openai, "OpenAI", return_value=client):
+            generator.generate_recommendation(rec.Transcript(source))
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "gpt-4.1-nano"
+
+    def test_returns_empty_string_when_the_model_returns_no_content(
+        self, full_env, tmp_path
+    ):
+        """A refusal or filtered response leaves content as None."""
+        source = tmp_path / "call.txt"
+        source.write_text("hello")
+        generator = rec.RecommendationsGenerator(rec.Config())
+        client = MagicMock()
+        client.chat.completions.create.return_value = _completion(None)
+
+        with patch.object(openai, "OpenAI", return_value=client):
+            result = generator.generate_recommendation(rec.Transcript(source))
+
+        assert result == ""
 
     def test_builds_the_client_with_the_configured_api_key(
         self, full_env, tmp_path
@@ -213,7 +267,7 @@ class TestGenerateRecommendation:
         source.write_text("hello")
         generator = rec.RecommendationsGenerator(rec.Config())
         client = MagicMock()
-        client.completions.create.return_value = _completion("text")
+        client.chat.completions.create.return_value = _completion("text")
 
         with patch.object(openai, "OpenAI", return_value=client) as factory:
             generator.generate_recommendation(rec.Transcript(source))
@@ -231,7 +285,11 @@ class TestGenerateRecommendation:
 
         assert "openai.Completion" not in source
         assert "openai.api_key" not in source
-        assert "client.completions.create" in source
+        assert "client.chat.completions.create" in source
+        # The legacy completions endpoint serves only gpt-3.5-turbo-instruct,
+        # which OpenAI has been retiring. Matches the quoted literal so the
+        # explanatory comment naming the old model does not trip this.
+        assert '"gpt-3.5-turbo-instruct"' not in source
 
 
 class TestPersistence:


### PR DESCRIPTION
`gpt-3.5-turbo-instruct` is the only model the legacy completions endpoint still serves, and OpenAI has been retiring it — so the feature was one model withdrawal away from breaking again, having just been repaired.

Switches to **chat completions with `gpt-4.1-mini`** — efficient tier, but noticeably better at following the structural instructions this prompt depends on (headings, bullets, ordering). Overridable via `OPENAI_MODEL`; the pinned library also accepts `gpt-4.1-nano`, `gpt-4o-mini`, `gpt-5-mini`, `gpt-5-nano`.

**The prompt is now split across roles** rather than concatenated: instructions as the system message, transcript as the user message. Chat models weight the two differently, so keeping the source text out of the instruction block stops a long transcript from diluting the formatting rules.

Also: `max_tokens` → `max_completion_tokens`, and the reply is unwrapped from `choices[].message.content` with a `""` fallback — a refusal or filtered response leaves that `None`, which would raise on `.strip()`.

Verified against the real library that `chat.completions.create` accepts every argument passed. 221 tests, 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)