### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
   pytest:
     needs: version
     runs-on: ubuntu-latest
+    env:
+      # Job level so the upload step's `if` can test it; a step's own env is
+      # not in scope for its own condition.
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       # Check out the repository code
       - uses: actions/checkout@v4
@@ -60,10 +64,15 @@ jobs:
       - name: ❯ Run pytest 🧪
         run: pytest
 
-      # pytest writes coverage.xml via --cov-report=xml. fail_ci_if_error is
-      # deliberately true: a silent upload failure is how the badge came to
-      # read "unknown" for years while the repo looked instrumented.
+      # pytest writes coverage.xml via --cov-report=xml.
+      #
+      # Skipped until CODECOV_TOKEN exists: Codecov rejects tokenless uploads
+      # on a protected branch ("Token required because branch is protected"),
+      # so without the secret this can only fail. Once set, fail_ci_if_error
+      # is deliberately true - a silent upload failure is how the badge came
+      # to read "unknown" while the repo looked instrumented.
       - name: ❯ Upload coverage to Codecov 📊
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,18 @@ jobs:
       - name: ❯ Run pytest 🧪
         run: pytest
 
+      # pytest writes coverage.xml via --cov-report=xml. fail_ci_if_error is
+      # deliberately true: a silent upload failure is how the badge came to
+      # read "unknown" for years while the repo looked instrumented.
+      - name: ❯ Upload coverage to Codecov 📊
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: unittests
+          fail_ci_if_error: true
+          verbose: true
+
   # This job runs flake8 to check for code style issues
   lint:
     needs: version


### PR DESCRIPTION
`pytest` already wrote `coverage.xml`; nothing consumed it — which is why the badge read "unknown" while the repo looked instrumented.

**Wiring it unconditionally does not work here.** Codecov answered the first attempt with:

```
HTTP 400 {"message":"Token required because branch is protected"}
```

Tokenless uploads are refused on a protected branch, so without the secret the step can only fail. It is therefore **skipped until `CODECOV_TOKEN` exists**, and runs with `fail_ci_if_error: true` once it does — a silent upload failure is the exact pattern that left the badge dead in the first place.

To enable it:

```
gh secret set CODECOV_TOKEN --repo sebastienrousseau/audioanalyser.github.io
```

(value from app.codecov.io → this repo → Settings)

The README badge stays off until an upload actually lands; restoring it first would only recreate the "unknown" badge removed in #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)