### PR TITLE
docs: restore the Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ width="261"
 <center>
 <!-- markdownlint-enable MD033 MD041 -->
 
-[![PyPI][pypi-badge]][03] [![PyPI Downloads][pypi-downloads-badge]][07] [![License][license-badge]][01] [![License][license-badge]][02]
+[![PyPI][pypi-badge]][03] [![PyPI Downloads][pypi-downloads-badge]][07] [![License][license-badge]][01] [![Codecov][codecov-badge]][06] [![License][license-badge]][02]
 
 • [Website][00]
 • [Report Bug][03]
@@ -770,10 +770,12 @@ of [audioanalyser][05] for their help and support.
 [03]: https://github.com/sebastienrousseau/audioanalyser.github.io/issues "Audio Analyser on GitHub"
 [04]: https://github.com/sebastienrousseau/audioanalyser.github.io/blob/main/CONTRIBUTING.md "Contributing Guidelines"
 [05]: https://github.com/sebastienrousseau/audioanalyser.github.io/graphs/contributors "Contributors"
+[06]: https://codecov.io/github/sebastienrousseau/audioanalyser.github.io?branch=main "Codecov"
 [07]: https://pypi.org/project/audioanalyser/ "Audio Analyser on PyPI"
 
 [banner]: https://cloudcdn.pro/audioanalyser/images/titles/title-audioanalyser.webp "Speech-to-Text & Analysis: Easy, Fast, Accurate."
 [diagram]: ./audio-analyser-architecture.png "Audio Analyser Architecture"
+[codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/audioanalyser.github.io?style=for-the-badge 'Codecov badge'
 [license-badge]: https://img.shields.io/pypi/l/audioanalyser?style=for-the-badge 'License badge'
 [pypi-badge]: https://img.shields.io/pypi/pyversions/audioanalyser.svg?style=for-the-badge 'PyPI badge'
 [pypi-downloads-badge]:https://img.shields.io/pypi/dm/audioanalyser.svg?style=for-the-badge 'PyPI Downloads badge'


### PR DESCRIPTION
Removed in #38 because no Codecov data had ever existed — nothing uploaded, so it rendered `coverage: unknown`.

Restored only after **both** conditions held, since either alone would have been misleading:

- the Codecov step on `main` reported `success`, not `skipped` — the earlier green `pytest` runs had merely *skipped* it, the secret having landed after they started
- the badge endpoint returned `coverage: 100%` rather than `unknown`

Verified no link reference is left dangling or orphaned in either direction. The old definition carried an upload token in the query string; the new one doesn't need it for a public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)